### PR TITLE
feat: LikedComment, ReportedComment CRD 구현

### DIFF
--- a/src/main/java/com/hana/app/data/dto/LikedCommentDto.java
+++ b/src/main/java/com/hana/app/data/dto/LikedCommentDto.java
@@ -1,0 +1,20 @@
+package com.hana.app.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LikedCommentDto {
+    private int likedCommentId;
+    private int commentId;
+    private int userId;
+    private LocalDate createDate;
+    private LocalDate updateDate;
+}

--- a/src/main/java/com/hana/app/data/dto/ReportedCommentDto.java
+++ b/src/main/java/com/hana/app/data/dto/ReportedCommentDto.java
@@ -1,0 +1,21 @@
+package com.hana.app.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReportedCommentDto {
+    private int reportedCommentId;
+    private String content;
+    private int userId;
+    private int commentId;
+    private LocalDate createDate;
+    private LocalDate updateDate;
+}

--- a/src/main/java/com/hana/app/frame/HanaRepository.java
+++ b/src/main/java/com/hana/app/frame/HanaRepository.java
@@ -2,7 +2,7 @@ package com.hana.app.frame;
 
 import java.util.List;
 
-public interface HanaRepository<K,V> {
+public interface HanaRepository<K, V> {
 
     int insert(V v) throws Exception;
     int delete(K k) throws Exception;

--- a/src/main/java/com/hana/app/repository/LikedCommentRepository.java
+++ b/src/main/java/com/hana/app/repository/LikedCommentRepository.java
@@ -1,0 +1,12 @@
+package com.hana.app.repository;
+
+import com.hana.app.data.dto.LikedCommentDto;
+import com.hana.app.frame.HanaRepository;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Mapper
+public interface LikedCommentRepository extends HanaRepository<Integer, LikedCommentDto> {
+
+}

--- a/src/main/java/com/hana/app/repository/ReportedCommentRepository.java
+++ b/src/main/java/com/hana/app/repository/ReportedCommentRepository.java
@@ -1,0 +1,12 @@
+package com.hana.app.repository;
+
+import com.hana.app.data.dto.ReportedCommentDto;
+import com.hana.app.frame.HanaRepository;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Mapper
+public interface ReportedCommentRepository extends HanaRepository<Integer, ReportedCommentDto> {
+
+}

--- a/src/main/java/com/hana/app/service/LikedCommentService.java
+++ b/src/main/java/com/hana/app/service/LikedCommentService.java
@@ -1,0 +1,41 @@
+package com.hana.app.service;
+
+import com.hana.app.data.dto.LikedCommentDto;
+import com.hana.app.frame.HanaService;
+import com.hana.app.repository.LikedCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LikedCommentService implements HanaService<Integer, LikedCommentDto> {
+
+    private final LikedCommentRepository likedCommentRepository;
+
+    @Override
+    public int add(LikedCommentDto likedCommentDto) throws Exception {
+        return likedCommentRepository.insert(likedCommentDto);
+    }
+
+    @Override
+    public int del(Integer id) throws Exception {
+        return likedCommentRepository.delete(id);
+    }
+
+    @Override
+    public int modify(LikedCommentDto likedCommentDto) throws Exception {
+        return likedCommentRepository.update(likedCommentDto);
+    }
+
+    @Override
+    public LikedCommentDto get(Integer id) throws Exception {
+        return likedCommentRepository.selectOne(id);
+    }
+
+    @Override
+    public List<LikedCommentDto> get() throws Exception {
+        return likedCommentRepository.select();
+    }
+}

--- a/src/main/java/com/hana/app/service/ReportedCommentService.java
+++ b/src/main/java/com/hana/app/service/ReportedCommentService.java
@@ -1,0 +1,41 @@
+package com.hana.app.service;
+
+import com.hana.app.data.dto.ReportedCommentDto;
+import com.hana.app.frame.HanaService;
+import com.hana.app.repository.ReportedCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportedCommentService implements HanaService<Integer, ReportedCommentDto> {
+
+    private final ReportedCommentRepository reportedCommentRepository;
+
+    @Override
+    public int add(ReportedCommentDto reportedCommentDto) throws Exception {
+        return reportedCommentRepository.insert(reportedCommentDto);
+    }
+
+    @Override
+    public int del(Integer id) throws Exception {
+        return reportedCommentRepository.delete(id);
+    }
+
+    @Override
+    public int modify(ReportedCommentDto reportedCommentDto) throws Exception {
+        return reportedCommentRepository.update(reportedCommentDto);
+    }
+
+    @Override
+    public ReportedCommentDto get(Integer id) throws Exception {
+        return reportedCommentRepository.selectOne(id);
+    }
+
+    @Override
+    public List<ReportedCommentDto> get() throws Exception {
+        return reportedCommentRepository.select();
+    }
+}

--- a/src/main/resources/mapper/commentmapper.xml
+++ b/src/main/resources/mapper/commentmapper.xml
@@ -16,8 +16,8 @@
     </select>
 
     <insert id="insert" parameterType="commentDto">
-        INSERT INTO comment (content, user_id, post_id, create_date, update_date)
-        VALUES (#{content}, #{userId}, #{postId}, NOW(), NOW());
+        INSERT INTO comment (content, user_id, post_id, create_date)
+        VALUES (#{content}, #{userId}, #{postId}, NOW());
     </insert>
 
     <update id="update" parameterType="commentDto">

--- a/src/main/resources/mapper/likedcommentmapper.xml
+++ b/src/main/resources/mapper/likedcommentmapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org/DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hana.app.repository.LikedCommentRepository">
+
+    <select id="selectOne" parameterType="Integer" resultType="likedCommentDto">
+        SELECT *
+        FROM liked_comment
+        WHERE liked_comment_id=#{likedCommentId}
+    </select>
+
+    <select id="select" resultType="likedCommentDto">
+        SELECT *
+        FROM liked_comment
+    </select>
+
+    <insert id="insert" parameterType="likedCommentDto">
+        INSERT INTO liked_comment (comment_id, user_id, create_date)
+        VALUES (#{commentId}, #{userId}, NOW());
+    </insert>
+
+    <delete id="delete" parameterType="Integer">
+        DELETE FROM liked_comment WHERE liked_comment_id=#{likedCommentId}
+    </delete>
+
+</mapper>

--- a/src/main/resources/mapper/reportedcommentmapper.xml
+++ b/src/main/resources/mapper/reportedcommentmapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org/DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hana.app.repository.ReportedCommentRepository">
+
+    <select id="selectOne" parameterType="Integer" resultType="reportedCommentDto">
+        SELECT *
+        FROM reported_comment
+        WHERE reported_comment_id=#{reportedCommentId}
+    </select>
+
+    <select id="select" resultType="reportedCommentDto">
+        SELECT *
+        FROM reported_comment
+    </select>
+
+    <insert id="insert" parameterType="reportedCommentDto">
+        INSERT INTO reported_comment (content, user_id, comment_id, create_date)
+        VALUES (#{content}, #{userId}, #{commentId}, NOW());
+    </insert>
+
+    <delete id="delete" parameterType="Integer">
+        DELETE FROM reported_comment WHERE reported_comment_id=#{reportedCommentId}
+    </delete>
+
+</mapper>

--- a/src/test/java/com/hana/comment/DeleteTests.java
+++ b/src/test/java/com/hana/comment/DeleteTests.java
@@ -19,7 +19,7 @@ class DeleteTests {
     @Test
     void contextLoads() {
         try {
-            commentService.del(1);
+            commentService.del(2);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/comment/InsertTests.java
+++ b/src/test/java/com/hana/comment/InsertTests.java
@@ -21,11 +21,9 @@ class InsertTests {
     @Test
     void contextLoads() {
         CommentDto commentDto = CommentDto.builder()
-                .content("댓글1")
+                .content("댓글입니다")
                 .userId(1)
                 .postId(1)
-                .createDate(LocalDate.now())
-                .updateDate(LocalDate.now())
                 .build();
         try {
             commentService.add(commentDto);

--- a/src/test/java/com/hana/likedcomment/DeleteTests.java
+++ b/src/test/java/com/hana/likedcomment/DeleteTests.java
@@ -1,0 +1,35 @@
+package com.hana.likedcomment;
+
+import com.hana.app.service.LikedCommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class DeleteTests {
+
+    @Autowired
+    LikedCommentService likedCommentService;
+
+    @Test
+    void contextLoads() {
+        try {
+            likedCommentService.del(1);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/likedcomment/InsertTests.java
+++ b/src/test/java/com/hana/likedcomment/InsertTests.java
@@ -1,0 +1,43 @@
+package com.hana.likedcomment;
+
+import com.hana.app.data.dto.CommentDto;
+import com.hana.app.data.dto.LikedCommentDto;
+import com.hana.app.service.LikedCommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+import java.time.LocalDate;
+
+@SpringBootTest
+@Slf4j
+class InsertTests {
+
+    @Autowired
+    LikedCommentService likedCommentService;
+
+    @Test
+    void contextLoads() {
+        LikedCommentDto likedCommentDto = LikedCommentDto.builder()
+                .commentId(2)
+                .userId(1)
+                .createDate(LocalDate.now())
+                .build();
+        try {
+            likedCommentService.add(likedCommentDto);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/likedcomment/SelectOneTests.java
+++ b/src/test/java/com/hana/likedcomment/SelectOneTests.java
@@ -1,0 +1,35 @@
+package com.hana.likedcomment;
+
+import com.hana.app.service.LikedCommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class SelectOneTests {
+
+    @Autowired
+    LikedCommentService likedCommentService;
+
+    @Test
+    void contextLoads() {
+        try {
+            likedCommentService.get(1);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/likedcomment/SelectTests.java
+++ b/src/test/java/com/hana/likedcomment/SelectTests.java
@@ -1,0 +1,35 @@
+package com.hana.likedcomment;
+
+import com.hana.app.service.LikedCommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class SelectTests {
+
+    @Autowired
+    LikedCommentService likedCommentService;
+
+    @Test
+    void contextLoads() {
+        try {
+            likedCommentService.get();
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/reportedcomment/DeleteTests.java
+++ b/src/test/java/com/hana/reportedcomment/DeleteTests.java
@@ -1,8 +1,6 @@
-package com.hana.likedcomment;
+package com.hana.reportedcomment;
 
-import com.hana.app.data.dto.CommentDto;
-import com.hana.app.data.dto.LikedCommentDto;
-import com.hana.app.service.LikedCommentService;
+import com.hana.app.service.ReportedCommentService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,23 +8,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
 
 @SpringBootTest
 @Slf4j
-class InsertTests {
+class DeleteTests {
 
     @Autowired
-    LikedCommentService likedCommentService;
+    ReportedCommentService reportedCommentService;
 
     @Test
     void contextLoads() {
-        LikedCommentDto likedCommentDto = LikedCommentDto.builder()
-                .commentId(2)
-                .userId(1)
-                .build();
         try {
-            likedCommentService.add(likedCommentDto);
+            reportedCommentService.del(1);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/reportedcomment/InsertTests.java
+++ b/src/test/java/com/hana/reportedcomment/InsertTests.java
@@ -1,8 +1,7 @@
-package com.hana.likedcomment;
+package com.hana.reportedcomment;
 
-import com.hana.app.data.dto.CommentDto;
-import com.hana.app.data.dto.LikedCommentDto;
-import com.hana.app.service.LikedCommentService;
+import com.hana.app.data.dto.ReportedCommentDto;
+import com.hana.app.service.ReportedCommentService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,23 +9,23 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
 
 @SpringBootTest
 @Slf4j
 class InsertTests {
 
     @Autowired
-    LikedCommentService likedCommentService;
+    ReportedCommentService reportedCommentService;
 
     @Test
     void contextLoads() {
-        LikedCommentDto likedCommentDto = LikedCommentDto.builder()
-                .commentId(2)
+        ReportedCommentDto reportedCommentDto = ReportedCommentDto.builder()
+                .content("내용이 노잼이라서 신고")
                 .userId(1)
+                .commentId(3)
                 .build();
         try {
-            likedCommentService.add(likedCommentDto);
+            reportedCommentService.add(reportedCommentDto);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/reportedcomment/SelectOneTests.java
+++ b/src/test/java/com/hana/reportedcomment/SelectOneTests.java
@@ -1,8 +1,6 @@
-package com.hana.likedcomment;
+package com.hana.reportedcomment;
 
-import com.hana.app.data.dto.CommentDto;
-import com.hana.app.data.dto.LikedCommentDto;
-import com.hana.app.service.LikedCommentService;
+import com.hana.app.service.ReportedCommentService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,23 +8,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
 
 @SpringBootTest
 @Slf4j
-class InsertTests {
+class SelectOneTests {
 
     @Autowired
-    LikedCommentService likedCommentService;
+    ReportedCommentService reportedCommentService;
 
     @Test
     void contextLoads() {
-        LikedCommentDto likedCommentDto = LikedCommentDto.builder()
-                .commentId(2)
-                .userId(1)
-                .build();
         try {
-            likedCommentService.add(likedCommentDto);
+            reportedCommentService.get(1);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/reportedcomment/SelectTests.java
+++ b/src/test/java/com/hana/reportedcomment/SelectTests.java
@@ -1,8 +1,6 @@
-package com.hana.likedcomment;
+package com.hana.reportedcomment;
 
-import com.hana.app.data.dto.CommentDto;
-import com.hana.app.data.dto.LikedCommentDto;
-import com.hana.app.service.LikedCommentService;
+import com.hana.app.service.ReportedCommentService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,23 +8,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
 
 import java.sql.SQLException;
-import java.time.LocalDate;
 
 @SpringBootTest
 @Slf4j
-class InsertTests {
+class SelectTests {
 
     @Autowired
-    LikedCommentService likedCommentService;
+    ReportedCommentService reportedCommentService;
 
     @Test
     void contextLoads() {
-        LikedCommentDto likedCommentDto = LikedCommentDto.builder()
-                .commentId(2)
-                .userId(1)
-                .build();
         try {
-            likedCommentService.add(likedCommentDto);
+            reportedCommentService.get();
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
- feat: LikedComment CRD 구현
- feat: ReportedComment CRD 구현
- cf. 실수로 branch 이동을 안 하고 작업해서 하나의 branch에 2개의 내용이 들어가 있습니다..
<br>

📌 관련 이슈
---
- #7 
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
- feat/liked_comment
- cf. 실수로 branch 이동을 안 하고 작업해서 하나의 branch에 2개의 내용이 들어가 있습니다..

<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
- LikedCommentDto,  ReportedCommentDto 파일 작성
- mapper 파일 작성
- Repository 파일 작성
- Service 파일 작성
- CRD Test program 작성 및 테스트 완료
- commentmapper update_date 값을 null로 수정
- InsertTests DTO 생성 시 createDate build 코드 삭제 (SQL에서 기본으로 생성하기 때문에 불필요한 코드)

<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
- 구현한 service 기능: select, selectOne, insert, delete
- insert 시 updateDate는 null

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
