### PR TITLE
feat/post : POST 관련 CRUD API 구현 완료

### DIFF
--- a/src/main/java/com/hana/app/data/dto/PostDto.java
+++ b/src/main/java/com/hana/app/data/dto/PostDto.java
@@ -1,0 +1,25 @@
+package com.hana.app.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostDto {
+    private int postId;
+    private String title;
+    private String content;
+    private boolean isAnonymous;
+    private int scraps;
+    private int likes;
+    private int userId;
+    private int boardId;
+    private LocalDate createDate;
+    private LocalDate updateDate;
+}

--- a/src/main/java/com/hana/app/repository/PostRepository.java
+++ b/src/main/java/com/hana/app/repository/PostRepository.java
@@ -1,0 +1,12 @@
+package com.hana.app.repository;
+
+import com.hana.app.data.dto.PostDto;
+import com.hana.app.frame.HanaRepository;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Mapper
+public interface PostRepository extends HanaRepository<Integer, PostDto> {
+
+}

--- a/src/main/java/com/hana/app/repository/PostRepository.java
+++ b/src/main/java/com/hana/app/repository/PostRepository.java
@@ -9,4 +9,7 @@ import org.springframework.stereotype.Repository;
 @Mapper
 public interface PostRepository extends HanaRepository<Integer, PostDto> {
 
+    int insertByAnonymous(PostDto postDto) throws Exception;
+    int insertByNotAnonymous(PostDto postDto) throws Exception;
+
 }

--- a/src/main/java/com/hana/app/service/PostService.java
+++ b/src/main/java/com/hana/app/service/PostService.java
@@ -17,9 +17,18 @@ public class PostService implements HanaService<Integer, PostDto> {
     private final PostRepository postRepository;
 
     @Override
-    public int add(PostDto postDto) throws Exception {
-        // 성공 시 1, 실패 시 0 return
+    public int add(PostDto postDto) throws  Exception {
         return postRepository.insert(postDto);
+    }
+
+    public int addByAnonymous(PostDto postDto) throws Exception {
+        // 성공 시 1, 실패 시 0 return
+        return postRepository.insertByAnonymous(postDto);
+    }
+
+    public int addByNotAnonymous(PostDto postDto) throws Exception {
+        // 성공 시 1, 실패 시 0 return
+        return postRepository.insertByNotAnonymous(postDto);
     }
 
     @Override

--- a/src/main/java/com/hana/app/service/PostService.java
+++ b/src/main/java/com/hana/app/service/PostService.java
@@ -1,0 +1,44 @@
+package com.hana.app.service;
+
+import com.hana.app.data.dto.CommentDto;
+import com.hana.app.data.dto.PostDto;
+import com.hana.app.frame.HanaService;
+import com.hana.app.repository.CommentRepository;
+import com.hana.app.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostService implements HanaService<Integer, PostDto> {
+
+    private final PostRepository postRepository;
+
+    @Override
+    public int add(PostDto postDto) throws Exception {
+        // 성공 시 1, 실패 시 0 return
+        return postRepository.insert(postDto);
+    }
+
+    @Override
+    public int del(Integer id) throws Exception {
+        return postRepository.delete(id);
+    }
+
+    @Override
+    public int modify(PostDto postDto) throws Exception {
+        return postRepository.update(postDto);
+    }
+
+    @Override
+    public PostDto get(Integer id) throws Exception {
+        return postRepository.selectOne(id);
+    }
+
+    @Override
+    public List<PostDto> get() throws Exception {
+        return postRepository.select();
+    }
+}

--- a/src/main/resources/mapper/postmapper.xml
+++ b/src/main/resources/mapper/postmapper.xml
@@ -17,12 +17,12 @@
 
     <insert id="insertByAnonymous" parameterType="postDto">
         INSERT INTO post (title, content, user_id, board_id, create_date)
-        VALUES (#{title}, #{content}, #{userId}, #{postId}, NOW());
+        VALUES (#{title}, #{content}, #{userId}, #{boardId}, NOW());
     </insert>
 
     <insert id="insertByNotAnonymous" parameterType="postDto">
         INSERT INTO post (title, content, is_anonymous, user_id, board_id, create_date)
-        VALUES (#{title}, #{content}, 0, #{userId}, #{postId}, NOW());
+        VALUES (#{title}, #{content}, 0, #{userId}, #{boardId}, NOW());
     </insert>
 
     <update id="update" parameterType="postDto">

--- a/src/main/resources/mapper/postmapper.xml
+++ b/src/main/resources/mapper/postmapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org/DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hana.app.repository.PostRepository">
+
+    <select id="selectOne" parameterType="Integer" resultType="postDto">
+        SELECT *
+        FROM post
+        WHERE post_id=#{postId}
+    </select>
+
+    <select id="select" resultType="postDto">
+        SELECT *
+        FROM post
+    </select>
+
+    <insert id="insertByAnonymous" parameterType="postDto">
+        INSERT INTO post (title, content, user_id, board_id, create_date)
+        VALUES (#{title}, #{content}, #{userId}, #{postId}, NOW());
+    </insert>
+
+    <insert id="insertByNotAnonymous" parameterType="postDto">
+        INSERT INTO post (title, content, is_anonymous, user_id, board_id, create_date)
+        VALUES (#{title}, #{content}, 0, #{userId}, #{postId}, NOW());
+    </insert>
+
+    <update id="update" parameterType="postDto">
+        UPDATE post
+        SET title=#{title}, is_anonymous=#{isAnonymous}, content=#{content}, update_date=NOW()
+        WHERE post_id=#{postId}
+    </update>
+
+    <delete id="delete" parameterType="Integer">
+        DELETE FROM post WHERE post_id=#{postId}
+    </delete>
+
+</mapper>

--- a/src/test/java/com/hana/post/DeleteTests.java
+++ b/src/test/java/com/hana/post/DeleteTests.java
@@ -1,6 +1,7 @@
 package com.hana.post;
 
 import com.hana.app.service.CommentService;
+import com.hana.app.service.PostService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,12 +15,12 @@ import java.sql.SQLException;
 class DeleteTests {
 
     @Autowired
-    CommentService commentService;
+    PostService postService;
 
     @Test
     void contextLoads() {
         try {
-            commentService.del(1);
+            postService.del(1);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/post/DeleteTests.java
+++ b/src/test/java/com/hana/post/DeleteTests.java
@@ -1,0 +1,35 @@
+package com.hana.post;
+
+import com.hana.app.service.CommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class DeleteTests {
+
+    @Autowired
+    CommentService commentService;
+
+    @Test
+    void contextLoads() {
+        try {
+            commentService.del(1);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/post/InsertByAnonymousTests.java
+++ b/src/test/java/com/hana/post/InsertByAnonymousTests.java
@@ -1,8 +1,6 @@
 package com.hana.post;
 
-import com.hana.app.data.dto.CommentDto;
 import com.hana.app.data.dto.PostDto;
-import com.hana.app.service.CommentService;
 import com.hana.app.service.PostService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -11,10 +9,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DuplicateKeyException;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 
 @SpringBootTest
 @Slf4j
-class UpdateTests {
+class InsertByAnonymousTests {
 
     @Autowired
     PostService postService;
@@ -22,12 +21,14 @@ class UpdateTests {
     @Test
     void contextLoads() {
         PostDto postDto = PostDto.builder()
-                .title("8일이라 쓰고 2주라 읽는 프로젝트")
-                .content("내용을 수정하겠다.")
-                .isAnonymous(false)
+                .title("8일간의 프로젝트 시작")
+                .content("일주일만에 끝내고 마지막은 회식 ㄱ")
+                .userId(1)
+                .boardId(1)
+                .createDate(LocalDate.now())
                 .build();
         try {
-            postService.modify(postDto);
+            postService.addByAnonymous(postDto);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/post/InsertByNotAnonymousTests.java
+++ b/src/test/java/com/hana/post/InsertByNotAnonymousTests.java
@@ -1,7 +1,7 @@
 package com.hana.post;
 
-import com.hana.app.data.dto.CommentDto;
-import com.hana.app.service.CommentService;
+import com.hana.app.data.dto.PostDto;
+import com.hana.app.service.PostService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,22 +13,22 @@ import java.time.LocalDate;
 
 @SpringBootTest
 @Slf4j
-class InsertTests {
+class InsertByNotAnonymousTests {
 
     @Autowired
-    CommentService commentService;
+    PostService postService;
 
     @Test
     void contextLoads() {
-        CommentDto commentDto = CommentDto.builder()
-                .content("댓글1")
+        PostDto postDto = PostDto.builder()
+                .title("8일간의 프로젝트 시작")
+                .content("일주일만에 끝내고 마지막은 회식 ㄱ")
                 .userId(1)
-                .postId(1)
+                .boardId(1)
                 .createDate(LocalDate.now())
-                .updateDate(LocalDate.now())
                 .build();
         try {
-            commentService.add(commentDto);
+            postService.addByNotAnonymous(postDto);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/post/InsertTests.java
+++ b/src/test/java/com/hana/post/InsertTests.java
@@ -1,0 +1,44 @@
+package com.hana.post;
+
+import com.hana.app.data.dto.CommentDto;
+import com.hana.app.service.CommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+import java.time.LocalDate;
+
+@SpringBootTest
+@Slf4j
+class InsertTests {
+
+    @Autowired
+    CommentService commentService;
+
+    @Test
+    void contextLoads() {
+        CommentDto commentDto = CommentDto.builder()
+                .content("댓글1")
+                .userId(1)
+                .postId(1)
+                .createDate(LocalDate.now())
+                .updateDate(LocalDate.now())
+                .build();
+        try {
+            commentService.add(commentDto);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/post/SelectOneTests.java
+++ b/src/test/java/com/hana/post/SelectOneTests.java
@@ -1,0 +1,35 @@
+package com.hana.post;
+
+import com.hana.app.service.CommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class SelectOneTests {
+
+    @Autowired
+    CommentService commentService;
+
+    @Test
+    void contextLoads() {
+        try {
+            commentService.get(1);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/post/SelectOneTests.java
+++ b/src/test/java/com/hana/post/SelectOneTests.java
@@ -1,6 +1,7 @@
 package com.hana.post;
 
 import com.hana.app.service.CommentService;
+import com.hana.app.service.PostService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,12 +15,12 @@ import java.sql.SQLException;
 class SelectOneTests {
 
     @Autowired
-    CommentService commentService;
+    PostService postService;
 
     @Test
     void contextLoads() {
         try {
-            commentService.get(1);
+            postService.get(1);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/post/SelectTests.java
+++ b/src/test/java/com/hana/post/SelectTests.java
@@ -1,6 +1,7 @@
 package com.hana.post;
 
 import com.hana.app.service.CommentService;
+import com.hana.app.service.PostService;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,12 +15,12 @@ import java.sql.SQLException;
 class SelectTests {
 
     @Autowired
-    CommentService commentService;
+    PostService postService;
 
     @Test
     void contextLoads() {
         try {
-            commentService.get();
+            postService.get();
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {

--- a/src/test/java/com/hana/post/SelectTests.java
+++ b/src/test/java/com/hana/post/SelectTests.java
@@ -1,0 +1,35 @@
+package com.hana.post;
+
+import com.hana.app.service.CommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class SelectTests {
+
+    @Autowired
+    CommentService commentService;
+
+    @Test
+    void contextLoads() {
+        try {
+            commentService.get();
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/post/UpdateTests.java
+++ b/src/test/java/com/hana/post/UpdateTests.java
@@ -1,0 +1,40 @@
+package com.hana.post;
+
+import com.hana.app.data.dto.CommentDto;
+import com.hana.app.service.CommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class UpdateTests {
+
+    @Autowired
+    CommentService commentService;
+
+    @Test
+    void contextLoads() {
+        CommentDto commentDto = CommentDto.builder()
+                .commentId(1)
+                .content("수정1")
+                .build();
+        try {
+            commentService.modify(commentDto);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/hana/post/UpdateTests.java
+++ b/src/test/java/com/hana/post/UpdateTests.java
@@ -22,6 +22,7 @@ class UpdateTests {
     @Test
     void contextLoads() {
         PostDto postDto = PostDto.builder()
+                .postId(4)
                 .title("8일이라 쓰고 2주라 읽는 프로젝트")
                 .content("내용을 수정하겠다.")
                 .isAnonymous(false)


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
POST 관련 CRUD API 구현 완료
TEST 코드 작성 및 정상 작동 확인
<br>

📌 관련 이슈
---
#8 POST 관련 CRUD API 전체부분 설계 완료
<br>

🧭 작업 브랜치
---
Feat/post
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
Post Dto 생성
Repository 및 Service 연결
Mybatis Mapper 설계
Test 코드 구현
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
POST 관련 CRUD API 전체부분 설계 완료했습니다.
이후, ResponsePostDto 생성을 통해 게시글 리스트 목록 조회를 위한 API 추가 설계 예정

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>