### PR TITLE
feat: 댓글의 좋아요 등록 여부 확인 기능 구현

### DIFF
--- a/src/main/java/com/hana/app/data/dto/IsLikedCommentDto.java
+++ b/src/main/java/com/hana/app/data/dto/IsLikedCommentDto.java
@@ -1,0 +1,17 @@
+package com.hana.app.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class IsLikedCommentDto extends CommentDto {
+    /* (SQL JOIN문을 통해 반환받는 데이터 DTO) */
+
+    // 댓글의 좋아요 등록 여부 정보가 포함된 정보
+    // null 값이면 등록 x, 아니면 등록 o
+    private int isLiked;
+}

--- a/src/main/java/com/hana/app/repository/CommentRepository.java
+++ b/src/main/java/com/hana/app/repository/CommentRepository.java
@@ -1,12 +1,19 @@
 package com.hana.app.repository;
 
 import com.hana.app.data.dto.CommentDto;
+import com.hana.app.data.dto.IsLikedCommentDto;
+import com.hana.app.data.dto.LikedPostDto;
 import com.hana.app.frame.HanaRepository;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @Mapper
 public interface CommentRepository extends HanaRepository<Integer, CommentDto> {
-
+    // 로그인 사용자가 댓글의 좋아요를 눌렀는지 확인하기 위한 기능
+    // isLiked column에 null 또는 not null 값이 들어간 isLikedCommentCheckDto List를 반환
+    List<IsLikedCommentDto> selectIsLikedComment(@Param("postId") Integer postId, @Param("userId") Integer userId);
 }

--- a/src/main/java/com/hana/app/service/CommentService.java
+++ b/src/main/java/com/hana/app/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.hana.app.service;
 
 import com.hana.app.data.dto.CommentDto;
+import com.hana.app.data.dto.IsLikedCommentDto;
 import com.hana.app.frame.HanaService;
 import com.hana.app.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +39,9 @@ public class CommentService implements HanaService<Integer, CommentDto> {
     @Override
     public List<CommentDto> get() throws Exception {
         return commentRepository.select();
+    }
+
+    public List<IsLikedCommentDto> getIsLikedComment(Integer postId, Integer userId) throws Exception {
+        return commentRepository.selectIsLikedComment(postId, userId);
     }
 }

--- a/src/main/resources/mapper/commentmapper.xml
+++ b/src/main/resources/mapper/commentmapper.xml
@@ -30,4 +30,14 @@
         DELETE FROM comment WHERE comment_id=#{commentId}
     </delete>
 
+    <select id="selectIsLikedComment" resultType="isLikedCommentDto">
+        SELECT *
+        FROM comment AS c
+        LEFT JOIN (SELECT comment_id AS is_liked
+                   FROM liked_comment
+                   WHERE user_id = #{userId}) AS lc
+        ON c.comment_id = lc.is_liked
+        WHERE c.post_id = #{postId};
+    </select>
+
 </mapper>

--- a/src/test/java/com/hana/comment/SelectIsLikedCommentTests.java
+++ b/src/test/java/com/hana/comment/SelectIsLikedCommentTests.java
@@ -1,0 +1,35 @@
+package com.hana.comment;
+
+import com.hana.app.service.CommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class SelectIsLikedCommentTests {
+
+    @Autowired
+    CommentService commentService;
+
+    @Test
+    void contextLoads() {
+        try {
+            commentService.getIsLikedComment(1, 2);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}


### PR DESCRIPTION
[#11]

# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
- feat: 댓글의 좋아요 등록 여부 확인 기능 구현
<br>

📌 관련 이슈
---
[#11] 
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
- feat/댓글_좋아요_여부_확인_기능_구현
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
- 해당 기능 구현을 위한 코드 작성
- mapper
- repository
- service
- DTO
- TEST program 작성
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
- DB comment table과 liked_comment table을 left join
- comment table에 is_liked column이 추가된 table(DTO)를 반환받는 기능 구현
- 게시글 상세 조회 페이지에서 해당 함수를 호출
- is_liked column의 값이 null인지 아닌지의 여부로, 로그인 된 사용자의 각 댓글 좋아요 등록 여부를 판단
- 이후 색이 있는 손가락(엄지척 그림)버튼을 출력할 건지 색이 없는 걸 출력할 건지 결정하여 출력
<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
