### PR TITLE
feat: comment delete mapper 수정

### DIFF
--- a/src/main/resources/mapper/commentmapper.xml
+++ b/src/main/resources/mapper/commentmapper.xml
@@ -26,9 +26,11 @@
         WHERE comment_id=#{commentId}
     </update>
 
-    <delete id="delete" parameterType="Integer">
-        DELETE FROM comment WHERE comment_id=#{commentId}
-    </delete>
+    <update id="delete" parameterType="Integer">
+        UPDATE comment
+        SET status="Deleted", update_date=NOW()
+        WHERE comment_id=#{commentId}
+    </update>
 
     <select id="selectIsLikedComment" resultType="isLikedCommentDto">
         SELECT *

--- a/src/test/java/com/hana/comment/DeleteTests.java
+++ b/src/test/java/com/hana/comment/DeleteTests.java
@@ -19,7 +19,7 @@ class DeleteTests {
     @Test
     void contextLoads() {
         try {
-            commentService.del(2);
+            commentService.del(3);
             log.info("---------- SUCCESS ----------");
         } catch (Exception e) {
             if(e instanceof SQLException) {


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
feat: comment delete mapper 수정
<br>

📌 관련 이슈
---

<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
feat/comment_delete_mapper수정
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
- comment delete할때 그냥 삭제가 아니라, status값을 "Deleted"값으로 변경
- DeleteTest완료
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
