### PR TITLE
feat: report 관련 구조 변경 및 기능 추가

### DIFF
--- a/src/main/java/com/hana/app/data/dto/ReportCategoryDto.java
+++ b/src/main/java/com/hana/app/data/dto/ReportCategoryDto.java
@@ -1,0 +1,17 @@
+package com.hana.app.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReportCategoryDto {
+    private int reportCategoryId;
+    private int name;
+}

--- a/src/main/java/com/hana/app/data/dto/ReportedCommentDto.java
+++ b/src/main/java/com/hana/app/data/dto/ReportedCommentDto.java
@@ -13,9 +13,9 @@ import java.time.LocalDate;
 @Builder
 public class ReportedCommentDto {
     private int reportedCommentId;
-    private String content;
     private int userId;
     private int commentId;
     private LocalDate createDate;
     private LocalDate updateDate;
+    private int reportCategoryId;
 }

--- a/src/main/java/com/hana/app/frame/HanaRepository.java
+++ b/src/main/java/com/hana/app/frame/HanaRepository.java
@@ -3,7 +3,6 @@ package com.hana.app.frame;
 import java.util.List;
 
 public interface HanaRepository<K, V> {
-
     int insert(V v) throws Exception;
     int delete(K k) throws Exception;
     int update(V v) throws Exception;;

--- a/src/main/java/com/hana/app/repository/LikedPostRepository.java
+++ b/src/main/java/com/hana/app/repository/LikedPostRepository.java
@@ -1,6 +1,5 @@
 package com.hana.app.repository;
 
-import com.hana.app.data.dto.LikedCommentDto;
 import com.hana.app.data.dto.LikedPostDto;
 import com.hana.app.frame.HanaRepository;
 import org.apache.ibatis.annotations.Mapper;

--- a/src/main/java/com/hana/app/repository/ReportedCommentRepository.java
+++ b/src/main/java/com/hana/app/repository/ReportedCommentRepository.java
@@ -1,12 +1,16 @@
 package com.hana.app.repository;
 
+import com.hana.app.data.dto.LikedPostDto;
 import com.hana.app.data.dto.ReportedCommentDto;
 import com.hana.app.frame.HanaRepository;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @Mapper
 public interface ReportedCommentRepository extends HanaRepository<Integer, ReportedCommentDto> {
-
+    // 신고 중복 여부 확인을 위해 userId와 commentId로 데이터를 select
+    // null이면 중복 x, 아니면 중복
+    ReportedCommentDto selectDuplicateOne(@Param("commentId") Integer commentId, @Param("userId") Integer userId);
 }

--- a/src/main/java/com/hana/app/service/ReportedCommentService.java
+++ b/src/main/java/com/hana/app/service/ReportedCommentService.java
@@ -38,4 +38,8 @@ public class ReportedCommentService implements HanaService<Integer, ReportedComm
     public List<ReportedCommentDto> get() throws Exception {
         return reportedCommentRepository.select();
     }
+
+    public ReportedCommentDto findDuplicateOne(Integer commentId, Integer userId) throws Exception {
+        return reportedCommentRepository.selectDuplicateOne(commentId, userId);
+    }
 }

--- a/src/main/resources/mapper/reportedcommentmapper.xml
+++ b/src/main/resources/mapper/reportedcommentmapper.xml
@@ -24,4 +24,10 @@
         DELETE FROM reported_comment WHERE reported_comment_id=#{reportedCommentId}
     </delete>
 
+    <select id="selectDuplicateOne" resultType="reportedCommentDto">
+        SELECT *
+        FROM reported_comment
+        WHERE comment_id=#{commentId} AND user_id=#{userId}
+    </select>
+
 </mapper>

--- a/src/main/resources/mapper/reportedcommentmapper.xml
+++ b/src/main/resources/mapper/reportedcommentmapper.xml
@@ -16,8 +16,8 @@
     </select>
 
     <insert id="insert" parameterType="reportedCommentDto">
-        INSERT INTO reported_comment (content, user_id, comment_id, create_date)
-        VALUES (#{content}, #{userId}, #{commentId}, NOW());
+        INSERT INTO reported_comment (user_id, comment_id, create_date, report_category_id)
+        VALUES (#{userId}, #{commentId}, NOW(), #{reportCategoryId});
     </insert>
 
     <delete id="delete" parameterType="Integer">

--- a/src/test/java/com/hana/reportedcomment/InsertTests.java
+++ b/src/test/java/com/hana/reportedcomment/InsertTests.java
@@ -20,10 +20,11 @@ class InsertTests {
     @Test
     void contextLoads() {
         ReportedCommentDto reportedCommentDto = ReportedCommentDto.builder()
-                .content("내용이 노잼이라서 신고")
                 .userId(1)
                 .commentId(3)
+                .reportCategoryId(1)
                 .build();
+
         try {
             reportedCommentService.add(reportedCommentDto);
             log.info("---------- SUCCESS ----------");

--- a/src/test/java/com/hana/reportedcomment/SelectDuplicateOneTests.java
+++ b/src/test/java/com/hana/reportedcomment/SelectDuplicateOneTests.java
@@ -1,0 +1,35 @@
+package com.hana.reportedcomment;
+
+import com.hana.app.service.ReportedCommentService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+
+@SpringBootTest
+@Slf4j
+class SelectDuplicateOneTests {
+
+    @Autowired
+    ReportedCommentService reportedCommentService;
+
+    @Test
+    void contextLoads() {
+        try {
+            reportedCommentService.findDuplicateOne(3, 1);
+            log.info("---------- SUCCESS ----------");
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
- feat: ReportedComment DTO 및 mapper 수정
- feat: comment 중복 신고 확인 기능 구현
<br>

📌 관련 이슈
---
- #26 
- #29 
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
- feat/report
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
- comment 중복 신고 확인 기능을 위해 mapper, repository, service 파일 코드 추가
- test program 동작 완료
- reported_comment table 구조 변경으로 인해 DTO, mapper 수정
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
