### PR TITLE
feat: 검색을 통한 게시글 리스트 조회 api 추가

### DIFF
--- a/src/main/java/com/hana/app/repository/PostRepository.java
+++ b/src/main/java/com/hana/app/repository/PostRepository.java
@@ -20,5 +20,5 @@ public interface PostRepository extends HanaRepository<Integer, PostDto> {
     int insertByNotAnonymous(PostDto postDto) throws Exception;
     int updateLikeCount(Integer id) throws Exception;
     int updateScrapCount(Integer id) throws Exception;
-
+    List<PostDto> selectByKeyword(@Param("boardId") Integer boardId, @Param("userId") Integer userId, @Param("keyword") String keyword) throws Exception;
 }

--- a/src/main/java/com/hana/app/service/PostService.java
+++ b/src/main/java/com/hana/app/service/PostService.java
@@ -76,4 +76,8 @@ public class PostService implements HanaService<Integer, PostDto> {
         // 성공 시 1, 실패 시 0 return
         return postRepository.updateScrapCount(id);
     }
+
+    public List<PostDto> selectByKeyword(Integer boardId, Integer userId, String keyword) throws Exception {
+        return postRepository.selectByKeyword(boardId, userId, keyword);
+    }
 }

--- a/src/main/resources/mapper/postmapper.xml
+++ b/src/main/resources/mapper/postmapper.xml
@@ -42,7 +42,7 @@
     </select>
 
     <select id="getPostList" resultType="postDto">
-        SELECT p.post_id, p.title, p.content, p.is_anonymous, p.create_date, p.likes, COUNT(c.comment_id) AS comment_count, is_liked, p.status
+        SELECT p.post_id, p.title, p.content, p.is_anonymous, p.create_date, p.likes, p.board_id, COUNT(c.comment_id) AS comment_count, is_liked, p.status
         FROM post p
         LEFT JOIN (SELECT *
                    FROM comment
@@ -121,4 +121,18 @@
         WHERE post_id=#{postId}
     </update>
 
+
+    <select id="selectByKeyword" resultType="postDto">
+        SELECT p.post_id, p.title, p.content, p.is_anonymous, p.create_date, p.likes, p.board_id, COUNT(c.comment_id) AS comment_count, is_liked, p.status
+        FROM post p
+                 LEFT JOIN (SELECT *
+                            FROM comment
+                            WHERE status &lt;&gt; "Deleted") AS c ON p.post_id = c.post_id
+                 LEFT JOIN (SELECT post_id, user_id AS is_liked
+                            FROM liked_post
+                            WHERE user_id = #{userId}) AS lp ON p.post_id = lp.post_id
+        WHERE p.board_id = #{boardId} AND p.status = "ACTIVE" AND (p.title LIKE CONCAT('%', #{keyword}, '%') OR p.content LIKE CONCAT('%', #{keyword}, '%'))
+        GROUP BY p.post_id, is_liked
+        ORDER BY p.create_date DESC
+    </select>
 </mapper>

--- a/src/test/java/com/hana/post/SelectByKeywordTests.java
+++ b/src/test/java/com/hana/post/SelectByKeywordTests.java
@@ -1,0 +1,39 @@
+package com.hana.post;
+
+import com.hana.app.data.dto.PostDto;
+import com.hana.app.service.PostService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
+
+import java.sql.SQLException;
+import java.util.List;
+
+@SpringBootTest
+@Slf4j
+public class SelectByKeywordTests {
+
+    @Autowired
+    PostService postService;
+
+    @Test
+    void contextLoads() {
+        try {
+            List<PostDto> postDtoList= postService.selectByKeyword(1, 1, "서윤");
+            for(PostDto p : postDtoList){
+                log.info(p.toString());
+            }
+        } catch (Exception e) {
+            if(e instanceof SQLException) {
+                log.info("---------- SQLException ----------");
+            } else if(e instanceof DuplicateKeyException) {
+                log.info("---------- DuplicateKeyException ----------");
+            } else {
+                log.info("---------- Else.. Run 'e.printStackTrace()' ----------");
+                e.printStackTrace();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
검색을 통한 게시글 리스트 조회 api 추가
<br>

📌 관련 이슈
---
#8 게시글 검색 API 구현
<!-- 관련된 이슈의 번호 및 내용 -->
<!-- ex) #1 - 마이 프로필 수정 api 구현 -->
<br>

🧭 작업 브랜치
---
refactor/push
<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
검색 로직 추가했습니다.
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---

<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
